### PR TITLE
Change domain from .so -> .io.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module abbey.so/terraform-provider-abbey
+module abbey.io/terraform-provider-abbey
 
 go 1.20
 

--- a/internal/abbey/provider.go
+++ b/internal/abbey/provider.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	abbeyprovider "abbey.so/terraform-provider-abbey/internal/abbey/provider"
-	grantkitresource "abbey.so/terraform-provider-abbey/internal/abbey/resources/grantkit"
-	identityresource "abbey.so/terraform-provider-abbey/internal/abbey/resources/identity"
+	abbeyprovider "abbey.io/terraform-provider-abbey/internal/abbey/provider"
+	grantkitresource "abbey.io/terraform-provider-abbey/internal/abbey/resources/grantkit"
+	identityresource "abbey.io/terraform-provider-abbey/internal/abbey/resources/identity"
 )
 
 const (
@@ -61,7 +61,7 @@ func (p *provider_) Schema(
 				Optional:            true,
 				Sensitive:           false,
 				Description:         "",
-				MarkdownDescription: "The Abbey API host. Defaults to `https://api.abbey.so`.",
+				MarkdownDescription: "The Abbey API host. Defaults to `https://api.abbey.io`.",
 				DeprecationMessage:  "",
 				Validators:          nil,
 			},

--- a/internal/abbey/provider/provider.go
+++ b/internal/abbey/provider/provider.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	DefaultHost = "https://api.abbey.so"
+	DefaultHost = "https://api.abbey.io"
 	TypePrefix  = "abbey"
 )
 

--- a/internal/abbey/resources/grantkit/grant_kit.go
+++ b/internal/abbey/resources/grantkit/grant_kit.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	. "github.com/moznion/go-optional"
 
-	"abbey.so/terraform-provider-abbey/internal/abbey/entity"
-	"abbey.so/terraform-provider-abbey/internal/abbey/resources/requestable"
+	"abbey.io/terraform-provider-abbey/internal/abbey/entity"
+	"abbey.io/terraform-provider-abbey/internal/abbey/resources/requestable"
 )
 
 type Model struct {

--- a/internal/abbey/resources/grantkit/output.go
+++ b/internal/abbey/resources/grantkit/output.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	"abbey.so/terraform-provider-abbey/internal/abbey/resources/requestable"
+	"abbey.io/terraform-provider-abbey/internal/abbey/resources/requestable"
 )
 
 type Output struct {

--- a/internal/abbey/resources/grantkit/policy.go
+++ b/internal/abbey/resources/grantkit/policy.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	. "github.com/moznion/go-optional"
 
-	"abbey.so/terraform-provider-abbey/internal/abbey/entity"
+	"abbey.io/terraform-provider-abbey/internal/abbey/entity"
 )
 
 type (

--- a/internal/abbey/resources/grantkit/resource.go
+++ b/internal/abbey/resources/grantkit/resource.go
@@ -18,9 +18,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"abbey.so/terraform-provider-abbey/internal/abbey/provider"
-	"abbey.so/terraform-provider-abbey/internal/abbey/resources/requestable"
-	abbeyvalidator "abbey.so/terraform-provider-abbey/validator"
+	"abbey.io/terraform-provider-abbey/internal/abbey/provider"
+	"abbey.io/terraform-provider-abbey/internal/abbey/resources/requestable"
+	abbeyvalidator "abbey.io/terraform-provider-abbey/validator"
 )
 
 var (

--- a/internal/abbey/resources/grantkit/resource_test.go
+++ b/internal/abbey/resources/grantkit/resource_test.go
@@ -6,15 +6,15 @@ import (
 	"os"
 	"testing"
 
+	"abbey.io/terraform-provider-abbey/internal/abbey"
+	abbeyprovider "abbey.io/terraform-provider-abbey/internal/abbey/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	. "github.com/onsi/gomega"
-
-	"abbey.so/terraform-provider-abbey/internal/abbey"
-	abbeyprovider "abbey.so/terraform-provider-abbey/internal/abbey/provider"
 )
 
 // var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/internal/abbey/resources/grantkit/step.go
+++ b/internal/abbey/resources/grantkit/step.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"abbey.so/terraform-provider-abbey/internal/abbey/entity"
-	"abbey.so/terraform-provider-abbey/internal/abbey/resources/requestable"
+	"abbey.io/terraform-provider-abbey/internal/abbey/entity"
+	"abbey.io/terraform-provider-abbey/internal/abbey/resources/requestable"
 )
 
 type Step struct {

--- a/internal/abbey/resources/grantkit/workflow.go
+++ b/internal/abbey/resources/grantkit/workflow.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	"abbey.so/terraform-provider-abbey/internal/abbey/resources/requestable"
+	"abbey.io/terraform-provider-abbey/internal/abbey/resources/requestable"
 )
 
 type Workflow struct {

--- a/internal/abbey/resources/identity/resource.go
+++ b/internal/abbey/resources/identity/resource.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	"abbey.so/terraform-provider-abbey/internal/abbey/provider"
+	"abbey.io/terraform-provider-abbey/internal/abbey/provider"
 )
 
 func New() Resource {

--- a/internal/abbey/resources/identity/resource_test.go
+++ b/internal/abbey/resources/identity/resource_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"abbey.so/terraform-provider-abbey/internal/abbey"
-	"abbey.so/terraform-provider-abbey/internal/abbey/provider"
+	"abbey.io/terraform-provider-abbey/internal/abbey"
+	"abbey.io/terraform-provider-abbey/internal/abbey/provider"
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/internal/abbey/resources/requestable/grant_tf.go
+++ b/internal/abbey/resources/requestable/grant_tf.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
-	"abbey.so/terraform-provider-abbey/internal/abbey/value"
+	"abbey.io/terraform-provider-abbey/internal/abbey/value"
 )
 
 type GrantTf struct {

--- a/internal/abbey/resources/requestable/requestable.go
+++ b/internal/abbey/resources/requestable/requestable.go
@@ -5,7 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	. "github.com/moznion/go-optional"
 
-	. "abbey.so/terraform-provider-abbey/internal/abbey/entity"
+	. "abbey.io/terraform-provider-abbey/internal/abbey/entity"
 )
 
 type Model struct {

--- a/internal/abbey/resources/requestable/workflow.go
+++ b/internal/abbey/resources/requestable/workflow.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"abbey.so/terraform-provider-abbey/internal/abbey/entity"
+	"abbey.io/terraform-provider-abbey/internal/abbey/entity"
 )
 
 const (

--- a/internal/abbey/resources/requestable/workflow_tf.go
+++ b/internal/abbey/resources/requestable/workflow_tf.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
-	"abbey.so/terraform-provider-abbey/internal/abbey/value"
+	"abbey.io/terraform-provider-abbey/internal/abbey/value"
 )
 
 var invalidWorkflow Workflow

--- a/main.go
+++ b/main.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 
-	"abbey.so/terraform-provider-abbey/internal/abbey"
-	"abbey.so/terraform-provider-abbey/internal/abbey/provider"
+	"abbey.io/terraform-provider-abbey/internal/abbey"
+	"abbey.io/terraform-provider-abbey/internal/abbey/provider"
 )
 
 // GoReleaser sets the version in compiled binaries.


### PR DESCRIPTION
This PR migrates the Abbey TF Provider from .so to .io.

- Change module path
- Update tests
