### PR TITLE
Update to PR mode

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -24,6 +24,7 @@ jobs:
         - terraform
       create_release: true
       force: ${{ github.event.inputs.force }}
+      mode: pr
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
- Current generations failing https://github.com/abbeylabs/terraform-provider-abbey/actions/runs/5570469093 because this repo does not allow merges to main. 
- Including `mode: pr` so Speakeasy terraform generation is opened as PRs for review which should prevent us from running into the above error