### PR TITLE
Mke `server_url` an optional field with default fallback value

### DIFF
--- a/.manifest.json
+++ b/.manifest.json
@@ -50,7 +50,7 @@
         "mockAcceptance": true,
         "providerGoModuleName": "abbey/v2",
         "providerName": "abbey",
-        "providerVersion": "0.2.7",
+        "providerVersion": "0.2.8",
         "githubRepoName": "terraform-provider-abbey"
       }
     },
@@ -78,7 +78,7 @@
     },
     "providerGoModuleName": "abbey/v2",
     "providerName": "abbey",
-    "providerVersion": "0.2.7",
+    "providerVersion": "0.2.8",
     "mockAcceptance": true,
     "hideComputedDiff": false
   },

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# abbey Terraform Provider 0.2.7
+# abbey Terraform Provider 0.2.8
 
 The public Abbey API. Used for integrating with Abbey and building interfaces to extend the Abbey platform. See https://docs.abbey.io for more information.
 This repository contains a Terraform provider that allows you to manage resources through the abbey API.
@@ -40,11 +40,11 @@ go build -o terraform-provider-abbey
 5. Move the provider to your plugins directory:
 
 ```bash
-mkdir -p ~/.terraform.d/plugins/example.com/user/abbey/0.2.7/<distribution>
-mv terraform-provider-abbey ~/.terraform.d/plugins/example.com/user/abbey/0.2.7/<distribution>
+mkdir -p ~/.terraform.d/plugins/example.com/user/abbey/0.2.8/<distribution>
+mv terraform-provider-abbey ~/.terraform.d/plugins/example.com/user/abbey/0.2.8/<distribution>
 ```
 
-Note: The directory structure is important. The provider must be located at `~/.terraform.d/plugins/example.com/user/abbey/0.2.7/<distribution>/terraform-provider-abbey`
+Note: The directory structure is important. The provider must be located at `~/.terraform.d/plugins/example.com/user/abbey/0.2.8/<distribution>/terraform-provider-abbey`
 Also please change `example.com/user` and `<distribution>` to match your real values.
 To get the <distribution> run `terraform version`, possible values: `linux_amd64`, `darwin_arm64`, `windows_amd64`, etc.
 
@@ -120,7 +120,7 @@ make acceptance-test
 1. Tag your release:
 
 ```bash
-git tag v0.2.7
+git tag v0.2.8
 git push --tags
 ```
 

--- a/examples/provider/main.tf
+++ b/examples/provider/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     abbey = {
       source  = "hashicorp.com/edu/abbey"
-      version = "0.2.7"
+      version = "0.2.8"
     }
   }
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -22,6 +22,9 @@ import (
 var _ provider.Provider = &Provider{}
 
 type Provider struct {
+	// version is set to the provider version on release, "dev" when the
+	// provider is built and ran locally, and "test" when running acceptance
+	// testing.
 	version string
 }
 
@@ -32,7 +35,7 @@ type abbeyProviderModel struct {
 
 func (p *Provider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
 	resp.TypeName = "abbey"
-	resp.Version = "0.2.7"
+	resp.Version = p.version
 }
 
 func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -39,7 +39,8 @@ func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp 
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"server_url": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
+				Required:    false,
 				Sensitive:   false,
 				Description: "The API host.",
 			},
@@ -61,13 +62,9 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		return
 	}
 
-	if dataModel.ServerUrl.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("server_url"),
-			"Unknown ServerUrl",
-			"Cannot create API client without server_url.",
-		)
-		return
+	serverUrl := dataModel.ServerUrl.ValueString()
+	if serverUrl == "" {
+		serverUrl = "https://api.abbey.io/v1"
 	}
 
 	if dataModel.BearerAuth.IsUnknown() {
@@ -80,7 +77,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 	}
 
 	config := clientconfig.NewConfig()
-	config.SetBaseUrl(dataModel.ServerUrl.ValueString())
+	config.SetBaseUrl(serverUrl)
 	config.SetAccessToken(dataModel.BearerAuth.ValueString())
 	apiClient := client.NewClient(config)
 


### PR DESCRIPTION
## What
- Make `server_url` an optional field with default value `https://api.abbey.io/v1`
- bump version in manifest, README, and TF example : `0.2.7`->`0.2.8`

## Why

## Checklist & Testing
*Does this change require any testing?*
An example of some testing to do:
- [x] : make test
